### PR TITLE
Better versioning

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -11,3 +11,7 @@ addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.4.10")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "1.2.0")
 
 addSbtPlugin("io.chrisdavenport" % "sbt-http4s-grpc" % "0.0.2")
+
+libraryDependencies ++= Seq(
+  "io.get-coursier" %% "coursier" % "2.1.0"
+)


### PR DESCRIPTION
The build is now given a global version, defining this "blend". This should be bumped when http4s-grpc version is bumped, shared modules are bumped (e.g. java protobuf, common), or we make any other configuration changes that affect generated code.

Each module is versioned `googleVersion+buildVersion`. It's `publish / skip` value is determined by checking to see if the artifact has already been published. This way publishing can run on every commit, but only new versions of artifacts will be published.