### PR TITLE
Faster ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,16 +64,8 @@ jobs:
       - name: Check that workflows are up to date
         run: sbt githubWorkflowCheck
 
-      - name: scalaJSLink
-        if: matrix.project == 'googleapis-http4sJS'
-        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' Test/scalaJSLinkerResult
-
-      - name: nativeLink
-        if: matrix.project == 'googleapis-http4sNative'
-        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' Test/nativeLink
-
-      - name: Test
-        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' test
+      - name: Compile
+        run: sbt 'project ${{ matrix.project }}' '++ ${{ matrix.scala }}' compile
 
       - name: Make target directories
         if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')

--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,10 @@ val Scala213 = "2.13.10"
 ThisBuild / crossScalaVersions := Seq(Scala213, "3.2.2")
 ThisBuild / scalaVersion := Scala213
 
+ThisBuild / githubWorkflowBuild := Seq(
+  WorkflowStep.Sbt(List("compile"), name = Some("Compile"))
+)
+
 def mkProject(
     id: String,
     module: String,


### PR DESCRIPTION
There are no tests, so linking tests for JS or Native is a waste of time. We just need to generate the source and compile the code.